### PR TITLE
Added the persistentcookiejar implementation from qt-webkit-kiosk

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Raspbian installed from image or NOOBS.
 
 	mkdir build
 	cd build
-	qmake DEFINES+=_BROWSER_ DEFINES+=_MOUSE_ DEFINES+=_PROPERTYCHANGER_ ../src/mlbrowser.pro
+	qmake DEFINES+=_BROWSER_ DEFINES+=_MOUSE_ DEFINES+=_PROPERTYCHANGER_ DEFINES+=_PERSISTENTCOOKIEJAR_ ../src/mlbrowser.pro
 
 *build*
 

--- a/src/mlbrowser.pro
+++ b/src/mlbrowser.pro
@@ -30,6 +30,11 @@ contains(DEFINES, _KEYFILTER_) {
 	SOURCES += mlkeyfilter.cpp
 }
 
+contains(DEFINES, _PERSISTENTCOOKIEJAR_) {
+	HEADERS += persistentcookiejar.h
+	SOURCES += persistentcookiejar.cpp
+}
+
 contains(DEFINES, _PROPERTYCHANGER_) {
 	HEADERS += mlpropertychanger.h
 	SOURCES += mlpropertychanger.cpp

--- a/src/mlwebkit.cpp
+++ b/src/mlwebkit.cpp
@@ -15,6 +15,9 @@
 #include "mlplayer.h"
 #endif
 
+#ifdef _PERSISTENTCOOKIEJAR_
+#include "persistentcookiejar.h"
+#endif
 
 #ifdef QT_OPENGL_LIB
 #undef QT_OPENGL_LIB
@@ -104,6 +107,10 @@ MLWebKit::MLWebKit(int overscanw, int overscanh, qreal zoom, int rotationMode)
     pWebview = new GraphicsWebView();
 
     pPage =  new WebPage();
+
+#ifdef _PERSISTENTCOOKIEJAR_
+    pPage->networkAccessManager()->setCookieJar(new PersistentCookieJar());
+#endif
 
     pFrame = pPage->mainFrame();
 

--- a/src/persistentcookiejar.cpp
+++ b/src/persistentcookiejar.cpp
@@ -1,0 +1,81 @@
+#include "persistentcookiejar.h"
+
+#include <QDebug>
+#include <QNetworkCookie>
+#include <QDir>
+#include <QFile>
+#include <QDesktopServices>
+
+
+const char *PersistentCookieJar::line_separator = "\n";
+
+PersistentCookieJar::PersistentCookieJar(QObject *parent) :
+    QNetworkCookieJar(parent)
+{
+    QString cookiejar_path = QStandardPaths::writableLocation(QStandardPaths::GenericDataLocation);
+
+    if (cookiejar_path.length() == 0) {
+        qDebug() << "No data locations available; not storing any cookies.";
+        cookiejar_location = "";
+        return;
+    }
+
+    QDir cookiejar_dir(cookiejar_path);
+    if (!cookiejar_dir.exists()) {
+        cookiejar_dir.mkpath(".");
+    }
+
+    cookiejar_location = cookiejar_path + QDir::toNativeSeparators("/cookiejar.txt");
+
+    load();
+}
+
+bool PersistentCookieJar::setCookiesFromUrl(const QList<QNetworkCookie> &cookieList, const QUrl &url)
+{
+    bool answer = QNetworkCookieJar::setCookiesFromUrl(cookieList, url);
+    if (cookiejar_location.length() != 0) {
+        store();
+    }
+    return answer;
+}
+
+void PersistentCookieJar::store() {
+    // qDebug() << "Writing cookies to " << cookiejar_location;
+
+    QFile storage(cookiejar_location);
+    storage.open(QIODevice::WriteOnly);
+
+    QList<QNetworkCookie> cookies = allCookies();
+
+    for (int i=0; i < cookies.length(); i++)
+    {
+        // qDebug() << "Writing cookie " << i;
+        storage.write(cookies[i].toRawForm());
+        storage.write(line_separator);
+    }
+
+    // qDebug() << "Wrote" << cookies.length() << "cookies to the cookiejar.";
+
+    storage.flush();
+    storage.close();
+}
+
+void PersistentCookieJar::load() {
+    qDebug() << "Loading cookies from" << cookiejar_location;
+
+    QFile storage(cookiejar_location);
+    storage.open(QIODevice::ReadOnly);
+    QByteArray bytes = storage.readAll();
+    QList<QByteArray> cookies = bytes.split(*line_separator);
+
+    QList<QNetworkCookie> all_cookies = QNetworkCookie::parseCookies(";");
+
+    for (int i=0; i < cookies.length(); i++) {
+        all_cookies += QNetworkCookie::parseCookies(cookies[i]);
+    }
+
+    setAllCookies(all_cookies);
+
+    qDebug() << "Read" << all_cookies.length() << "valid cookies from the cookiejar.";
+    storage.close();
+}

--- a/src/persistentcookiejar.h
+++ b/src/persistentcookiejar.h
@@ -1,0 +1,24 @@
+#ifndef PERSISTENTCOOKIEJAR_H
+#define PERSISTENTCOOKIEJAR_H
+
+#include <QNetworkCookieJar>
+
+class PersistentCookieJar : public QNetworkCookieJar
+{
+    Q_OBJECT
+public:
+    explicit PersistentCookieJar(QObject *parent = 0);
+
+    bool setCookiesFromUrl(const QList<QNetworkCookie> &cookieList, const QUrl &url);
+    void store();
+    void load();
+private:
+    QString cookiejar_location;
+    static const char *line_separator;
+signals:
+
+public slots:
+
+};
+
+#endif // PERSISTENTCOOKIEJAR_H


### PR DESCRIPTION
The implementation is taken from https://github.com/sergey-dryabzhinsky/qt-webkit-kiosk and slightly altered for the more recent QT5 stuff. I think this could help many people, especially if you would login via VNC once, then playout via linuxfb or eglfs.